### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -5,6 +5,10 @@ on:
     - cron: '30 21 * * *'  # 03:00 AM IST
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   report:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/rajtilak-2020/K-Rajtilak_s-Portfolio-V4/security/code-scanning/1](https://github.com/rajtilak-2020/K-Rajtilak_s-Portfolio-V4/security/code-scanning/1)

To fix the issue, we need to add the `permissions` key at the root of the workflow file to limit the scope of access granted to the `GITHUB_TOKEN`. Since the workflow requires write access for the `Commit and Push Report` step and potentially read access to repository contents, we will explicitly define these permissions. The `permissions` block will be added before the `jobs` section, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
